### PR TITLE
[MI-2825]:Fixed issue #240 edited the pretext

### DIFF
--- a/webapp/src/components/post_type_zoom/post_type_zoom.jsx
+++ b/webapp/src/components/post_type_zoom/post_type_zoom.jsx
@@ -79,7 +79,7 @@ export default class PostTypeZoom extends React.PureComponent {
         let content;
         let subtitle;
         if (props.meeting_status === 'STARTED') {
-            preText = 'I have started a meeting';
+            preText = post.message;
             if (this.props.fromBot) {
                 preText = `${this.props.creatorName} has started a meeting`;
             }
@@ -127,7 +127,7 @@ export default class PostTypeZoom extends React.PureComponent {
                 );
             }
         } else if (props.meeting_status === 'ENDED') {
-            preText = 'The meeting has ended';
+            preText = post.message;
             if (this.props.fromBot) {
                 preText = `${this.props.creatorName} has ended the meeting`;
             }


### PR DESCRIPTION
**Summary** 

- Users were not able to edit the pretext message of the post for starting a new zoom meeting due to hardcoded message.
- This PR contains all the changes from [Pr #248](https://github.com/mattermost/mattermost-plugin-zoom/pull/248) So this PR alone is enough to fix this issue so we can close [Pr #248](https://github.com/mattermost/mattermost-plugin-zoom/pull/248) afterward.

**Issue** 

- Fixes https://github.com/mattermost/mattermost-plugin-zoom/issues/240
- [Pr #248](https://github.com/mattermost/mattermost-plugin-zoom/pull/248) 